### PR TITLE
Fix i18n unauthenticated index page

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -115,7 +115,7 @@ function routing() {
         requesting(req, res, opts);
     });
 
-    router.get('/api/messages', isUser, function(req, res) {
+    router.get('/api/messages', function(req, res) {
         var languages = req.acceptsLanguages();
         for(language in languages){
             switch (languages[language]){

--- a/views/index.jade
+++ b/views/index.jade
@@ -1,12 +1,13 @@
 extends layout
 
 block content
-  .grey.lighten-4(style='display: flex;align-items: center;justify-content: center; height: 100%;')
-    .row(style='text-align:center;')
-      h2 #{messages.api.title}
-      .divider
-      h5 #{messages.api.index}
-      br
-      a.waves-effect.waves-light.btn.teal.darken-1(href='/preferences')
-        | #{messages.api.action.connection}
-        i.material-icons.right lock_open
+    #app.container
+      .grey.lighten-4(style='display: flex;align-items: center;justify-content: center; height: 100%;')
+        .row(style='text-align:center;')
+          h2 {{messages.api.title}}
+          .divider
+          h5 {{messages.api.index}}
+          br
+          a.waves-effect.waves-light.btn.teal.darken-1(href='/preferences')
+            | {{messages.api.action.connection}}
+            i.material-icons.right lock_open


### PR DESCRIPTION
Sans cette modification, les messages ne sont pas traduits dans la page d'accueil d'esup-otp-manager lorsqu'on n'est pas connecté et donc la page d'accueil est en anglais même si le navigateur demande le français.
Une fois authentifié, les pages reprennent bien les messages en français.

