### PR TITLE
Fix and improve selection of browser language

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -116,16 +116,12 @@ function routing() {
     });
 
     router.get('/api/messages', isUser, function(req, res) {
-        var languages = req.acceptsLanguages();
-        for(language in languages){
-            switch (languages[language]){
-                case "fr":
-                case "fr-FR": res.json(require("../properties/messages_fr.json"));break;
-                case "en":
-                case "en-US": res.json(require("../properties/messages_en.json")); break;
-                default : res.json(require("../properties/messages.json")); break;
-            }
-        }
+        var lang = req.acceptsLanguages('fr', 'en');
+	if(lang) {
+	    res.json(require("../properties/messages_" + lang + ".json")); 
+	} else {
+	    res.json(require("../properties/messages.json"));
+	}
     });
 
     router.get('/api/messages/:language', isUser, function(req, res) {


### PR DESCRIPTION
Corrige la sélection de la langue en utilisant Express

Avec plusieurs préférences de langues de configurées dans le navigateur, une exception est actuellement levée dans les logs (pas d'effet de bord pour l'utilisateur cependant)

Error: Can't set headers after they are sent.
    at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:369:11)
    at ServerResponse.header (/opt/esup-otp-manager/node_modules/express/lib/response.js:767:10)
    at ServerResponse.send (/opt/esup-otp-manager/node_modules/express/lib/response.js:170:12)
    at done (/opt/esup-otp-manager/node_modules/express/lib/response.js:1004:10)
    at Object.exports.renderFile (/opt/esup-otp-manager/node_modules/jade/lib/index.js:374:12)
    at View.exports.__express [as engine] (/opt/esup-otp-manager/node_modules/jade/lib/index.js:417:11)
    at View.render (/opt/esup-otp-manager/node_modules/express/lib/view.js:135:8)
    at tryRender (/opt/esup-otp-manager/node_modules/express/lib/application.js:640:10)
    at EventEmitter.render (/opt/esup-otp-manager/node_modules/express/lib/application.js:592:3)
    at ServerResponse.render (/opt/esup-otp-manager/node_modules/express/lib/response.js:1008:7)
