### PR TITLE
Fix image.flaticon.com : http->https 

### DIFF
--- a/views/templates/push-method.jade
+++ b/views/templates/push-method.jade
@@ -37,7 +37,7 @@ script#push-method(type='text/x-template').
     <div class="card-panel grey lighten-3">
     <div class="row" style="margin-bottom: 0;">
     <div class="col s3">
-    <img src="http://image.flaticon.com/icons/svg/186/186239.svg">
+    <img src="https://image.flaticon.com/icons/svg/186/186239.svg">
     </div>
     <div class="col s9">
     <span>{{user.methods.push.device.platform}}</span>


### PR DESCRIPTION
Prevents warning message 'mixed content' :

> Mixed Content: The page at 'https://esup-otp-manager.univ-ville.fr/preferences#' was loaded over HTTPS, but requested an insecure element 'http://image.flaticon.com/icons/svg/186/186239.svg'. This request was automatically upgraded to HTTPS, For more information see https://blog.chromium.org/2019/10/no-more-mixed-messages-about-https.html