### PR TITLE
CSS for printing bypass-method codes

### DIFF
--- a/public/stylesheets/style-print-bypass-method-codes.css
+++ b/public/stylesheets/style-print-bypass-method-codes.css
@@ -1,0 +1,17 @@
+body {
+ visibility: hidden;
+}
+
+.bypass-method-codes a {
+ display: none;
+} 
+
+.bypass-method-codes {
+ visibility: visible;
+ left: 0px;
+ top: 0px;
+ position:absolute;
+ font-size: 200%;
+ border-spacing: 0 1.5em;
+}
+

--- a/views/templates/bypass-method.jade
+++ b/views/templates/bypass-method.jade
@@ -9,7 +9,9 @@ script#bypass-method(type='text/x-template').
     <th data-field="code">{{messages.api.methods.bypass.generated_codes}}</th>
     </tr>
     </thead>
-    <tbody>
+    <tbody class="bypass-method-codes">
+    <a href="javascript:if(window.print)window.print()"><i class="material-icons md-48">print</i></a>
+    <link rel="stylesheet" href="/stylesheets/style-print-bypass-method-codes.css" media="print"/>
     <tr v-for="code in user.methods.bypass.codes">
     <td>{{code}}</td>
     </tr>


### PR DESCRIPTION
With this, user can print by-pass codes on paper with a printer and even cut each if desired !