### PR TITLE
Improve OTP-Manager general layout accessibility

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -16,7 +16,7 @@ function routing() {
     router.get('/manager/users_methods', isUser, function(req, res) {
         res.send({ ...properties.esup.users_methods, user: req.user });
     });
-    
+
     router.get('/manager/infos', isUser, function(req, res) {
         res.send({
             api_url: properties.esup.api_url,

--- a/server/routes/pagesRoutes.js
+++ b/server/routes/pagesRoutes.js
@@ -8,9 +8,11 @@ function isUser(req, res, next) {
 
 exports.routing = function(router, passport) {
     router.get('/', function(req, res) {
+        var reqMessages = utils.getMessagesForRequest(req);
         res.render('index', {
-            title: 'Esup Otp Manager',
-            messages: utils.getMessagesForRequest(req).messages,
+            title: 'ESUP OTP Manager',
+            messages: reqMessages.messages,
+            lang: reqMessages.lang
         });
     });
 

--- a/views/index.jade
+++ b/views/index.jade
@@ -1,12 +1,12 @@
 extends layout.jade
 
 block content
-    #app.container
+    main#app.container
       .grey.lighten-4(style='display: flex;align-items: center;justify-content: center; height: 100%;')
-        .row(style='text-align:center;')
-          h2= messages.api.title
+        .row.center
+          h1= messages.api.title
           .divider
-          h5= messages.api.index
+          p= messages.api.index
           br
           a.waves-effect.waves-light.btn.teal.darken-1(href='/preferences')
             | #{messages.api.action.connection}

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,9 +1,9 @@
 doctype html
-html
+html(lang=lang)
     head
         title ESUP OTP Manager
         meta(charset='UTF-8')
-        link(href='/stylesheets/material-icons.css', rel='stylesheet', type='text/css')
+        link(rel='stylesheet', type='text/css', href='/stylesheets/material-icons.css')
         link(rel='stylesheet', type='text/css', href='/css/materialize.min.css', media='screen,projection')
         link(rel='stylesheet', type='text/css', href='/stylesheets/style.css')
         meta(name='viewport', content='width=device-width, initial-scale=1.0')

--- a/views/templates/bypass-method.jade
+++ b/views/templates/bypass-method.jade
@@ -18,7 +18,7 @@ script#bypass-method(type='text/x-template').
     </tbody>
     </table>
     </ul>
-    <div class="row" style="text-align:center;">
+    <div class="row center">
     <a class="waves-effect waves-light btn" @click=generate_bypass>{{messages.api.action.generate_codes}}<i class="material-icons right" aria-hidden="true">sync</i></a>
     </div>
     <div class="divider"></div>


### PR DESCRIPTION
Hello,
this is my first PR to improve the accessibility of OTP Manager.
It is based on the "master" branch but maybe you prefer that I base it on "develop"?
Do we need to talk in english or french here?
Feel free to specify if there are other contribution rules to respect.

Here are details about changes made :
* Put "lang" value in "/" route
* Replace #app.container div by main for more explicit client layout
* Replace H2 by H1 in index.jade and H5 by P
* put lang attribute in html tag for general layout