### PR TITLE
2nd pass of Accessibility & Typo corrections

### DIFF
--- a/properties/messages_en.json
+++ b/properties/messages_en.json
@@ -77,7 +77,7 @@
         "description": "Method for connecting via smartphone notifications with Esup Auth",
         "push_confirmation1": "Please scan this code in the smartphone application",
         "push_confirmation2": "If your smartphone does not have a functional picture appreil or you are having difficulties to scan the code above. Go to the menu \"Settings \" then click \"Activate without scan \".",
-        "push_confirmation3": "Enter you login:",
+        "push_confirmation3": "Enter your login:",
         "push_confirmation4": "Enter your activation code:",
         "push_confirmation5": "Enter this hostname:",
         "push_confirmation6": "Then press 'Ok'"

--- a/properties/messages_en.json
+++ b/properties/messages_en.json
@@ -46,13 +46,13 @@
         "verify_code": {
           "sms": {
             "title": "Code received by SMS",
-            "pre": "A code has been sent to you by SMS to the number <b>",
-            "post": "</b>. <br />Please enter the code received to validate this number"
+            "pre": "A code has been sent to you by SMS to the number <strong>",
+            "post": "</strong>. <br />Please enter the code received to validate this number"
           },
           "mail": {
             "title": "Code received by email",
-            "pre": "A code has been sent to you by email to the address <b>",
-            "post": "</b>. <br />Please enter the code received to validate this email address"
+            "pre": "A code has been sent to you by email to the address <strong>",
+            "post": "</strong>. <br />Please enter the code received to validate this email address"
           },
           "wrong": "Incorrect code."
         }
@@ -77,9 +77,9 @@
         "description": "Method for connecting via smartphone notifications with Esup Auth",
         "push_confirmation1": "Please scan this code in the smartphone application",
         "push_confirmation2": "If your smartphone does not have a functional picture appreil or you are having difficulties to scan the code above. Go to the menu \"Settings \" then click \"Activate without scan \".",
-        "push_confirmation3": "Enter you login :",
-        "push_confirmation4": "Enter your activation code :",
-        "push_confirmation5": "Enter this hostname :",
+        "push_confirmation3": "Enter you login:",
+        "push_confirmation4": "Enter your activation code:",
+        "push_confirmation5": "Enter this hostname:",
         "push_confirmation6": "Then press 'Ok'"
       },
       "esupnfc": {
@@ -89,7 +89,7 @@
       "webauthn": {
           "name": "Hardware authenticator (WebAuthn)",
           "description": "WebAuthn hardware authentication factor (Smartphone, Windows Hello, TouchID, ...).",
-          "no_authentificators": "You have no authentificators registered. Register one ?",
+          "no_authentificators": "You have no authentificators registered. Register one?",
           "single_auth": "You have 1 authentification method registered.",
           "nb_of_auths": "You have %NB% authentification methods registered.",
           "new_name": "New name"
@@ -110,28 +110,30 @@
     },
     "index": "Single use passwords management interface",
     "action":{
-      "connection" : "Login",
-      "activate" : "Activate",
+      "connection": "Login",
+      "activate": "Activate",
       "validate": "Validate",
-      "deactivate" : "Deactivate",
-      "save" : "Save",
-      "modify" : "Modify",
-      "rename" : "Rename",
-      "remove" : "Remove",
-      "search" : "Search",
-      "select" : "Select",
+      "deactivate": "Deactivate",
+      "save": "Save",
+      "modify": "Modify",
+      "rename": "Rename",
+      "remove": "Remove",
+      "search": "Search",
+      "select": "Select",
       "cancel": "Cancel",
-      "add" : "Add",
-      "generate_codes" : "Generate codes",
-      "generate_qrcode" : "Generate QRCode",
-      "logout" : "Logout",
-      "confirm_deactivate" : "Do you want to deactivate ?",
-      "confirm_generate" :"Old codes will be erased. Continue ?",
+      "change_lang": "Change interface language",
+      "add": "Add",
+      "generate_codes": "Generate codes",
+      "generate_qrcode": "Generate QRCode",
+      "language": "Language",
+      "logout": "Logout",
+      "confirm_deactivate": "Do you want to deactivate?",
+      "confirm_generate":"Old codes will be erased. Continue?",
       "hide_menu": "Hide menu",
       "show_menu": "Show menu",
 
       "webauthn": {
-        "confirm_delete": "Do you really want to delete %NAME% ?"
+        "confirm_delete": "Do you really want to delete %NAME%?"
       }
     },
     "key": {
@@ -141,15 +143,15 @@
     "menu":{
       "home": "Home",
       "preferences": "Preferences",
-      "manager" : "Manager",
+      "manager": "Manager",
       "admin": "Administration"
     },
     "transports":{
-      "sms" : "Sms",
-      "mail" : "Mail"
+      "sms": "Sms",
+      "mail": "Mail"
     },
     "label":{
-      "user" : "User"
+      "user": "User"
     }
   }
 }

--- a/properties/messages_fr.json
+++ b/properties/messages_fr.json
@@ -23,10 +23,10 @@
 
     "webauthn": {
       "generic": "Une erreur est survenue. Veuillez réessayer.",
-      "timeout": "Vous avez dépassé le temps maximal autorisé pour l'ajout du facteur. Veuillez réessayer.",
-      "registration_failed": "Une erreur est survenue pendant l'ajout du facteur. Veuillez réessayer.",
-      "already_registered": "Vous avez déjà ajouté ce facteur d'authentification.",
-      "user_declined": "Vous avez annulé l'ajout du facteur.",
+      "timeout": "Vous avez dépassé le temps maximal autorisé pour l’ajout du facteur. Veuillez réessayer.",
+      "registration_failed": "Une erreur est survenue pendant l’ajout du facteur. Veuillez réessayer.",
+      "already_registered": "Vous avez déjà ajouté ce facteur d’authentification.",
+      "user_declined": "Vous avez annulé l’ajout du facteur.",
       "delete_failed": "Une erreur est survenue pendant la suppression du facteur. Veuillez réessayer.",
       "empty_name": "Le nom ne peut pas être vide"
     }
@@ -36,30 +36,30 @@
       "totp": {
         "name": "Code temporel (TOTP)",
         "description": "Méthode permettant de générer des codes uniques de 6 chiffres.",
-        "howTo": "Scannez le code à l'aide de votre application mobile Esup Auth ou Google Authentificator ou entrez le code directement dans votre application TOTP favori",
-        "howToActivate": "Ensuite, pour valider l'activation du TOTP, saisissez ci-dessous le code à 6 chiffres affiché sur votre application",
+        "howTo": "Scannez le code à l’aide de votre application mobile Esup Auth ou Google Authentificator ou entrez le code directement dans votre application TOTP favori",
+        "howToActivate": "Ensuite, pour valider l’activation du TOTP, saisissez ci-dessous le code à 6 chiffres affiché sur votre application",
         "enter_code": "Saisissez le code de 6 chiffres"
       },
       "random_code": {
         "name": "Code par SMS",
-        "description": "Méthode permettant de s'authentifier à partir d'un code aléatoire à usage unique envoyé par SMS.",
+        "description": "Méthode permettant de s’authentifier à partir d’un code aléatoire à usage unique envoyé par SMS.",
         "verify_code": {
           "sms": {
             "title": "Code reçu par SMS",
-            "pre": "Un code vous a été envoyé par SMS au numéro <b>",
-            "post": "</b>. <br />Veuillez indiquer le code reçu pour valider ce numéro."
+            "pre": "Un code vous a été envoyé par SMS au numéro <strong>",
+            "post": "</strong>. <br />Veuillez indiquer le code reçu pour valider ce numéro."
           },
           "mail": {
-            "title": "Code reçu par email",
-            "pre": "Un code vous a été envoyé par email à l'adresse <b>",
-            "post": "</b>. <br />Veuillez indiquer le code reçu pour valider cette adresse email."
+            "title": "Code reçu par courriel",
+            "pre": "Un code vous a été envoyé par courriel à l’adresse <strong>",
+            "post": "</strong>.<br /> Veuillez indiquer le code reçu pour valider cette adresse email."
           },
           "wrong": "Code incorrect."
         }
       },
       "random_code_mail": {
         "name": "Code par Courriel",
-        "description": "Méthode permettant de s'authentifier à partir d'un code aléatoire à usage unique envoyé par courriel."
+        "description": "Méthode permettant de s’authentifier à partir d’un code aléatoire à usage unique envoyé par courriel."
       },
       "bypass": {
         "name": "Codes de secours",
@@ -69,18 +69,18 @@
         "used_codes": "Codes utilisés"
       },
       "matrix": {
-        "name": "Grille d'authentification",
+        "name": "Grille d’authentification",
         "description": "Méthode permettant de se connecter via une grille."
       },
       "push": {
         "name": "Notification (Esup Auth)",
-        "description": "Méthode permettant de se connecter via les notifications de son smartphone avec l'application Esup Auth.",
-        "push_confirmation1": "Veuillez scannez ce code dans l'application smartphone Esup Auth",
-        "push_confirmation2": "Si votre smartphone ne dispose pas d'un appreil photo fonctionnel ou que vous épprouvez des difficultés à scanner le code précédent. Allez dans le menu \"Paramètres\" puis cliquer sur \"Activation manuelle\".",
-        "push_confirmation3": "Entrez votre nom de compte :",
-        "push_confirmation4": "Entrez le code d'activation :",
-        "push_confirmation5": "Entrez l'adresse :",
-        "push_confirmation6": "Puis cliquez sur 'Ok'"
+        "description": "Méthode permettant de se connecter via les notifications de son smartphone avec l’application Esup Auth.",
+        "push_confirmation1": "Veuillez scannez ce code dans l’application smartphone Esup Auth",
+        "push_confirmation2": "Si votre smartphone ne dispose pas d’un appareil photo fonctionnel ou que vous éprouvez des difficultés à scanner le code précédent. Allez dans le menu « Paramètres » puis cliquer sur « Activation manuelle ».",
+        "push_confirmation3": "Entrez votre nom de compte :",
+        "push_confirmation4": "Entrez le code d’activation :",
+        "push_confirmation5": "Entrez l’adresse :",
+        "push_confirmation6": "Puis cliquez sur « Ok »"
       },
       "esupnfc": {
           "name": "EsupNFC",
@@ -88,69 +88,71 @@
       },
       "webauthn": {
         "name": "Facteur physique (WebAuthn)",
-        "description": "Facteur physique d'authentification WebAuthn (Smartphone, Windows Hello, TouchID, ...).",
-        "no_authentificators": "Vous n'avez pas de moyen d'authentification enregistré. En ajouter un ?",
-        "single_auth": "Vous avez 1 moyen d'authentification.",
-        "nb_of_auths": "Vous avez %NB% moyens d'authentification.",
+        "description": "Facteur physique d’authentification WebAuthn (Smartphone, Windows Hello, TouchID, ...).",
+        "no_authentificators": "Vous n’avez pas de moyen d’authentification enregistré. En ajouter un ?",
+        "single_auth": "Vous avez 1 moyen d’authentification.",
+        "nb_of_auths": "Vous avez %NB% moyens d’authentification.",
         "new_name": "Nouveau nom"
       }
     },
     "home": {
-      "description": "Vous permet d'ajouter un deuxième niveau de protection à votre compte (authentification double facteur). Ainsi, il sera impossible d'accéder à votre compte même avec votre mot de passe.",
-      "methods":"Vous pouvez définir :",
-      "push":"qu'une notification / push soit envoyée sur l'application Esup Auth (Android, iOS).",
-      "totp":"qu'un code (TOTP) soit généré dans une application (Esup Auth, Authenticator, Plugin OTP...).",
-      "bypass":"qu'une liste de code à usage unique soit générée aléatoirement (Codes de secours).",
-      "esupnfc":"une connexion en badgeant avec votre carte d'étudiant ou professionnelle.",
-      "random_code":"qu'un code à usage unique vous soit envoyé par SMS.",
-      "random_code_mail":"qu'un code à usage unique vous soit envoyé par Courriel.",
-      "webauthn":"Facteur physique d'authentification WebAuthn (Smartphone, Windows Hello, TouchID, ...).",
+      "description": "Vous permet d’ajouter un deuxième niveau de protection à votre compte (authentification double facteur). Ainsi, il sera impossible d’accéder à votre compte même avec votre mot de passe.",
+      "methods": "Vous pouvez définir :",
+      "push": "qu’une notification / push soit envoyée sur l’application Esup Auth (Android, iOS).",
+      "totp": "qu’un code (TOTP) soit généré dans une application (Esup Auth, Authenticator, Plugin OTP...).",
+      "bypass": "qu’une liste de code à usage unique soit générée aléatoirement (Codes de secours).",
+      "esupnfc": "une connexion en badgeant avec votre carte d’étudiant ou professionnelle.",
+      "random_code": "qu’un code à usage unique vous soit envoyé par SMS.",
+      "random_code_mail": "qu’un code à usage unique vous soit envoyé par Courriel.",
+      "webauthn": "Facteur physique d’authentification WebAuthn (Smartphone, Windows Hello, TouchID, ...).",
       "activated": "Activé",
       "deactivated": "Désactivé",
-      "note":"Dans vos préférences, nous vous conseillons fortement de paramétrer au moins 2 méthodes afin de pouvoir assurer la continuité d'utilisation des services numériques."
+      "note": "Dans vos préférences, nous vous conseillons fortement de paramétrer au moins 2 méthodes afin de pouvoir assurer la continuité d’utilisation des services numériques."
     },
     "index": "Interface de gestion de mots de passe à usage unique",
     "action":{
-      "connection" : "Se connecter",
-      "activate" : "Activer",
+      "connection": "Se connecter",
+      "activate": "Activer",
       "validate": "Valider",
-      "deactivate" : "Désactiver",
-      "save" : "Enregistrer",
-      "modify" : "Modifier",
-      "rename" : "Renommer",
-      "remove" : "Supprimer",
-      "search" : "Chercher",
-      "select" : "Sélectionner",
+      "deactivate": "Désactiver",
+      "save": "Enregistrer",
+      "modify": "Modifier",
+      "rename": "Renommer",
+      "remove": "Supprimer",
+      "search": "Chercher",
+      "select": "Sélectionner",
       "cancel": "Annuler",
-      "add" : "Ajouter",
-      "generate_codes" : "Générer des codes",
-      "generate_qrcode" : "Générer QRCode",
-      "logout" : "Se déconnecter",
-      "confirm_deactivate" : "Voulez-vous vraiment désactiver ?",
-      "confirm_generate" :"Les anciens codes seront invalidés. Voulez-vous continuer ?",
+      "change_lang": "Changer la langue de l’interface",
+      "add": "Ajouter",
+      "generate_codes": "Générer des codes",
+      "generate_qrcode": "Générer QRCode",
+      "language": "Langue",
+      "logout": "Se déconnecter",
+      "confirm_deactivate": "Voulez-vous vraiment désactiver ?",
+      "confirm_generate": "Les anciens codes seront invalidés. Voulez-vous continuer ?",
       "hide_menu": "Masquer le menu",
       "show_menu": "Afficher le menu",
 
       "webauthn": {
-        "confirm_delete": "Voulez vous vraiment supprimer %NAME% ?"
+        "confirm_delete": "Voulez vous vraiment supprimer %NAME% ?"
       }
     },
     "key": {
       "escape": "echap"
     },
-    "title":"ESUP OTP Manager",
+    "title": "ESUP OTP Manager",
     "menu":{
       "home": "Accueil",
       "preferences": "Préférences",
-      "manager" : "Manager",
+      "manager": "Manager",
       "admin": "Administrateur"
     },
     "transports":{
-      "sms" : "Votre numéro portable",
-      "mail" : "Email"
+      "sms": "Votre numéro portable",
+      "mail": "Email"
     },
     "label":{
-      "user" : "Utilisateur"
+      "user": "Utilisateur"
     }
   }
 }

--- a/public/javascripts/app.js
+++ b/public/javascripts/app.js
@@ -88,9 +88,9 @@ function base64URLStringToBuffer(base64URLString) {
 /**
 * Convert the given array buffer into a Base64URL-encoded string. Ideal for converting various
 * credential response ArrayBuffers to string for sending back to the server as JSON.
-* 
+*
 * Helper method to compliment `base64URLStringToBuffer`
-* 
+*
 * source: https://github.com/MasterKale/SimpleWebAuthn/blob/master/packages/browser/src/helpers/bufferToBase64URLString.ts
 */
 function bufferToBase64URLString(buffer) {
@@ -198,7 +198,7 @@ const TotpMethod = Vue.extend({
                 uri: this.formatApiUri("/totp/activate/confirm/" + totpCode),
                 onSuccess: res => {
                     if (res.data.code != "Ok") {
-                        toast('Erreur, veuillez réessayer.', 3000, 'red darken-1');
+                        toast('Erreur, veuillez réessayer.', 9000, 'red darken-1');
                     } else {
                         this.user.methods.totp.active = true;
                         this.user.methods.totp.qrCode = '';
@@ -208,7 +208,7 @@ const TotpMethod = Vue.extend({
                 },
                 onStatus: {
                     401: res => {
-                        toast(this.messages.api.methods.random_code.verify_code.wrong, 3000, 'red darken-1');
+                        toast(this.messages.api.methods.random_code.verify_code.wrong, 9000, 'red darken-1');
                     }
                 }
             });
@@ -318,11 +318,11 @@ const WebAuthnMethod = Vue.extend({
                     } catch (e) {
                         console.error(e);
                     }
-                    
+
                     if (statusCode == 200) {
                         toast(this.messages.success.webauthn.renamed, 3000, 'green contrasted');
                     } else {
-                        toast(this.messages.error.webauthn.generic, 3000, 'red darken-1');
+                        toast(this.messages.error.webauthn.generic, 9000, 'red darken-1');
                     }
 
                 }
@@ -362,7 +362,7 @@ const WebAuthnMethod = Vue.extend({
                     if (statusCode == 200) {
                         toast(this.messages.success.webauthn.deleted, 3000, 'green contrasted');
                     } else {
-                        toast(this.messages.error.webauthn.delete_failed, 3000, 'red darken-1');
+                        toast(this.messages.error.webauthn.delete_failed, 9000, 'red darken-1');
                     }
 
                 }
@@ -423,7 +423,7 @@ const WebAuthnMethod = Vue.extend({
                         }
                     };
                 }
-                
+
                 await fetchApi({
                     method: "POST",
                     uri: this.formatApiUri("/webauthn/confirm_activate"),
@@ -437,25 +437,25 @@ const WebAuthnMethod = Vue.extend({
                             await this.renameAuthenticator(credentials.id);
                         }
                         else {
-                            toast(this.messages.error.webauthn.registration_failed, 3000, 'red darken-1');
+                            toast(this.messages.error.webauthn.registration_failed, 9000, 'red darken-1');
                         }
                     },
                     onStatus: {422: () => {
-                        toast(this.messages.error.webauthn.timeout, 3000, 'red darken-1');
+                        toast(this.messages.error.webauthn.timeout, 9000, 'red darken-1');
                     }},
                 });
             }
             catch(e) {
                 // Already registered
                 if(e.name === "InvalidStateError") {
-                    toast(this.messages.error.webauthn.already_registered, 3000, 'red darken-1');
+                    toast(this.messages.error.webauthn.already_registered, 9000, 'red darken-1');
                 }
                 // user said no / something like that
                 else if(e.name === "NotAllowedError") {
-                    toast(this.messages.error.webauthn.user_declined, 3000, 'red darken-1');
+                    toast(this.messages.error.webauthn.user_declined, 9000, 'red darken-1');
                 }
                 else {
-                    toast(this.messages.error.webauthn.generic, 3000, 'red darken-1');
+                    toast(this.messages.error.webauthn.generic, 9000, 'red darken-1');
                     console.error("/api/webauthn/confirm_activate", e);
                 }
             } finally {
@@ -498,7 +498,7 @@ const RandomCodeMethod = Vue.extend({
                 });
                 const data = res.data;
                 if (data.code != "Ok") {
-                    toast('Erreur interne, veuillez réessayer plus tard.', 3000, 'red darken-1');
+                    toast('Erreur interne, veuillez réessayer plus tard.', 9000, 'red darken-1');
                 } else {
                     const expected = data.otp;
 
@@ -533,7 +533,7 @@ const RandomCodeMethod = Vue.extend({
                             });
                             const data = res.data;
                             if (data.code != "Ok") {
-                                toast('Erreur interne, veuillez réessayer plus tard.', 3000, 'red darken-1');
+                                toast('Erreur interne, veuillez réessayer plus tard.', 9000, 'red darken-1');
                             } else {
                                 // equivalent to "this.user.transports[transport] = new_transport;", but allows new reactive property to be added dynamically
                                 Vue.set(this.user.transports, transport, new_transport);
@@ -546,7 +546,7 @@ const RandomCodeMethod = Vue.extend({
 
 
             } catch (err) {
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
             };
         },
         deleteTransport: function(transport) {
@@ -563,7 +563,7 @@ const RandomCodeMethod = Vue.extend({
                 },
             }).catch(err => {
                 this.user.transports[transport] = oldTransport;
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
             });
         },
     },
@@ -653,7 +653,7 @@ var UserDashboard = Vue.extend({
                     }
                 },
             }).catch(err => {
-                toast('Erreur interne, veuillez réessayer plus tard.', 3000, 'red darken-1');
+                toast('Erreur interne, veuillez réessayer plus tard.', 9000, 'red darken-1');
             });
         },
         standardActivate: function(method) {
@@ -669,7 +669,7 @@ var UserDashboard = Vue.extend({
                     }
                 },
             }).catch(err => {
-                toast('Erreur interne, veuillez réessayer plus tard.', 3000, 'red darken-1');
+                toast('Erreur interne, veuillez réessayer plus tard.', 9000, 'red darken-1');
             });
         },
         deactivate: function(method) {
@@ -692,7 +692,7 @@ var UserDashboard = Vue.extend({
                     },
                 }).catch(err => {
                     this.user.methods[method].active = true;
-                    toast(err, 3000, 'red darken-1');
+                    toast(err, 9000, 'red darken-1');
                 });
             }
         },
@@ -717,7 +717,7 @@ var UserDashboard = Vue.extend({
                     }
                 },
             }).catch(err => {
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
                 throw err;
             });
         },
@@ -737,7 +737,7 @@ var UserDashboard = Vue.extend({
                     }
                 },
             }).catch(err => {
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
                 throw err;
             });
         }
@@ -823,7 +823,7 @@ var UserView = Vue.extend({
                     }
                 },
             }).catch(err => {
-                toast('Erreur interne, veuillez réessayer plus tard.', 3000, 'red darken-1');
+                toast('Erreur interne, veuillez réessayer plus tard.', 9000, 'red darken-1');
             });
         },
         standardActivate: function(method) {
@@ -839,14 +839,14 @@ var UserView = Vue.extend({
                     }
                 },
             }).catch(err => {
-                toast('Erreur interne, veuillez réessayer plus tard.', 3000, 'red darken-1');
+                toast('Erreur interne, veuillez réessayer plus tard.', 9000, 'red darken-1');
             });
         },
         deactivate: function(method) {
             if (window.confirm(this.messages.api.action.confirm_deactivate)) {
                 if (this.user.methods[method].askActivation)
                     this.user.methods[method].askActivation = false;
-                
+
                 return fetchApi({
                     method: "PUT",
                     uri: "/api/admin/" + this.user.uid + "/" + method + "/deactivate",
@@ -861,7 +861,7 @@ var UserView = Vue.extend({
                     },
                 }).catch(err => {
                     this.user.methods[method].active = true;
-                    toast(err, 3000, 'red darken-1');
+                    toast(err, 9000, 'red darken-1');
                 });
             }
         },
@@ -884,7 +884,7 @@ var UserView = Vue.extend({
                     }
                 },
             }).catch(err => {
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
                 throw err;
             });
         },
@@ -904,7 +904,7 @@ var UserView = Vue.extend({
                     }
                 },
             }).catch(err => {
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
                 throw err;
             });
         },
@@ -950,7 +950,7 @@ var ManagerDashboard = Vue.extend({
                 this.uids = res.data.uids;
             },
         }).catch(err => {
-            toast(err, 3000, 'red darken-1');
+            toast(err, 9000, 'red darken-1');
         });
     },
     mounted: async function() {
@@ -986,7 +986,7 @@ var ManagerDashboard = Vue.extend({
                     this.setUser(data);
                 },
             }).catch(err => {
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
             });
         },
         setUser: function(data) {
@@ -1025,7 +1025,7 @@ var AdminDashboard = Vue.extend({
             }).catch(err => {
                 event.target.checked = false;
                 this.methods[event.target.name].activate = false;
-                toast('Erreur interne, veuillez réessayer plus tard.', 3000, 'red darken-1');
+                toast('Erreur interne, veuillez réessayer plus tard.', 9000, 'red darken-1');
             });
         },
         deactivate: function(event) {
@@ -1044,7 +1044,7 @@ var AdminDashboard = Vue.extend({
             }).catch(err => {
                 event.target.checked = true;
                 this.methods[event.target.name].activate = true;
-                toast('Erreur interne, veuillez réessayer plus tard.', 3000, 'red darken-1');
+                toast('Erreur interne, veuillez réessayer plus tard.', 9000, 'red darken-1');
             });
         },
         activateTransport: function(method, transport) {
@@ -1060,7 +1060,7 @@ var AdminDashboard = Vue.extend({
                     }
                 },
             }).catch(err => {
-                toast('Erreur interne, veuillez réessayer plus tard.', 3000, 'red darken-1');
+                toast('Erreur interne, veuillez réessayer plus tard.', 9000, 'red darken-1');
             });
         },
         deactivateTransport: function(method, transport) {
@@ -1079,7 +1079,7 @@ var AdminDashboard = Vue.extend({
                     }
                 },
             }).catch(err => {
-                toast('Erreur interne, veuillez réessayer plus tard.', 3000, 'red darken-1');
+                toast('Erreur interne, veuillez réessayer plus tard.', 9000, 'red darken-1');
             });
         },
     }
@@ -1198,7 +1198,7 @@ var app = new Vue({
                     this.setUser(res.data);
                 },
             }).catch(err => {
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
             });
         },
 
@@ -1222,7 +1222,7 @@ var app = new Vue({
                 this.users_methods = users_methods;
                 this.setMethods(methods);
             } catch (err) {
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
             }
         },
         getInfos: async function() {
@@ -1232,7 +1232,7 @@ var app = new Vue({
                     uri: "/manager/infos",
                 })).data;
             } catch (err) {
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
             }
         },
         setMethods: function (data) {
@@ -1251,7 +1251,7 @@ var app = new Vue({
                     localStorage.setItem("lang", lang);
                 },
             }).catch(err => {
-                toast(err, 3000, 'red darken-1');
+                toast(err, 9000, 'red darken-1');
             });
         },
         setMessages: function (data) {

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -72,9 +72,9 @@ h5, .h5{font-size: 1rem;}
 }
 
 nav {
-    background-color: #424242 ;
+    background-color: #424242;
 }
-header { background:#424242; }
+header { background: #424242; }
 
 .no-margin {
     margin: 0;
@@ -89,10 +89,10 @@ header { background:#424242; }
 }
 
 #closebtn {
-    color: #bbb ;
+    color: #bbb;
     height: initial !important;
     line-height: initial !important;
-    margin: 0px 0 32px 74px;
+    margin: 0 0 32px 74px;
     padding: 0 16px;
 }
 
@@ -210,7 +210,7 @@ body.IE7 .Switch.Round {
 #slide-out li.active,
 #slide-out li.active a {
     background-color: #24847C;
-    color: white ;
+    color: white;
 }
 #slide-out li.active a:hover { background-color: inherit; } /* overrride materializeCSS */
 
@@ -227,7 +227,7 @@ body.IE7 .Switch.Round {
 }
 
 
-/* Page d'Accueil et les blocs méthodes */
+/* Page d'accueil et les blocs méthodes */
 
 .container {width: 86%; max-width: 1200px}
 
@@ -315,11 +315,11 @@ label { color: #555; font-size: 1.2rem; }
 @media only screen and (max-width: 700px) {
     .methode {  width:46% !important; }
     .methode img { width:70px; }
-    .lock-solid { width:130px; margin: 3px 15px 0px ; }
+    .lock-solid { width:130px; margin: 3px 15px 0; }
 }
 
 @media only screen and (max-width: 480px) {
-    .methode { width:96% !important ; }
+    .methode { width:96% !important; }
     .methode img { width:60px; }
 }
 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -10,15 +10,21 @@ body,
     min-width: 100%;
     padding: 0;
     margin: 0;
-    font-family: "Roboto", arial, sans-serif;
+    font-family: Roboto, arial, sans-serif;
 }
- 
+
 
 header,
 main,
 footer {
-    padding-left: 245px;  
+    padding-left: 245px;
 }
+
+h1, .h1{font-size: 3.56rem;}
+h2, .h2{font-size: 2.92rem;}
+h3, .h3{font-size: 2.28rem;}
+h4, .h4{font-size: 1.64rem;}
+h5, .h5{font-size: 1rem;}
 
 .side-nav.fixed { width: 245px; }
 
@@ -37,13 +43,15 @@ footer {
     justify-content: center;
 }
 
-.top-nav {
+.top-nav, .top-nav h1 {
     box-shadow: none;
     font-size: 32px;
+    line-height: 64px;
     -webkit-font-smoothing: antialiased;
 }
 
 #slide-out{
+    transform: none;
     -webkit-transform: none;
 }
 
@@ -73,6 +81,7 @@ header { background:#424242; }
 }
 
 .sidenav-header {
+    background-color: #000;
     background-image: url("../images/wallpaper_polygons.jpg") !important;
     background-size: 150% 500%;
     background-repeat: no-repeat;
@@ -196,18 +205,19 @@ body.IE7 .Switch.Round {
 }
 
 
-#slide-out { border: 1px solid #ccc; color: #444; } 
+#slide-out { border: 1px solid #ccc; color: #444; }
 
-#slide-out  li.active { background-color: #24847C; }
-
-#slide-out  li.active a:hover { background-color: inherit; } /* overrride materializeCSS */
-
-#slide-out  li.active #home { color:white ; }
+#slide-out li.active,
+#slide-out li.active a {
+    background-color: #24847C;
+    color: white ;
+}
+#slide-out li.active a:hover { background-color: inherit; } /* overrride materializeCSS */
 
 #slide-out .collapsible-header  {
-    background-color : #eeeef0;  
-    border-bottom: 1px solid #ddd; 
-    border-top: 1px solid #ddd; 
+    background-color : #eeeef0;
+    border-bottom: 1px solid #ddd;
+    border-top: 1px solid #ddd;
     margin: 0;
     text-transform: uppercase;
 }
@@ -217,16 +227,16 @@ body.IE7 .Switch.Round {
 }
 
 
-/* Page d'Accueil et les blocs méthodes */ 
+/* Page d'Accueil et les blocs méthodes */
 
-.container {width: 86%; max-width: 1200px} 
+.container {width: 86%; max-width: 1200px}
 
 
 
 .flex-container {
-  display: flex; 
+  display: flex;
   flex-wrap: wrap;
-  margin-top: 19px; 
+  margin-top: 19px;
 }
 
 .status {
@@ -260,9 +270,9 @@ body.IE7 .Switch.Round {
 .methode img {  padding: 0px; margin:0px; width:88px; }
 .lock-solid { width:110px; margin: 0px 30px 0px 30px; }
 
-.card { padding-top:25px;  background-color: #eeeef0; } 
+.card { padding-top:25px;  background-color: #eeeef0; }
+
 .input-field label {
-    top: 2rem;
     top: 1rem;
     left: 10px;
     color: #6C6C6C;
@@ -298,8 +308,8 @@ label { color: #555; font-size: 1.2rem; }
     margin: 0;
 }
 
-@media only screen and (min-width: 701px) {  
-             .container {width: 86%; max-width: 1200px} 
+@media only screen and (min-width: 701px) {
+    .container {width: 86%; max-width: 1200px}
 }
 
 @media only screen and (max-width: 700px) {
@@ -310,7 +320,7 @@ label { color: #555; font-size: 1.2rem; }
 
 @media only screen and (max-width: 480px) {
     .methode { width:96% !important ; }
-    .methode img { width:60px; } 
+    .methode img { width:60px; }
 }
 
 @media only screen and (min-width: 992px) {
@@ -325,7 +335,7 @@ label { color: #555; font-size: 1.2rem; }
     #slide-out.may-be-hidden {
         display:none;
     }
-    
+
     /* hide the "menu" button if the menu is already displayed */
     header:not(:has(#slide-out.may-be-hidden)) #navButton {
         display: none;
@@ -368,7 +378,7 @@ label { color: #555; font-size: 1.2rem; }
     background-color: #CC332F!important;
 }
 
-  
+
 .btn:hover,
 .btn:focus,
 .btn-large:hover,

--- a/views/dashboard.jade
+++ b/views/dashboard.jade
@@ -22,7 +22,7 @@ block content
                     button#navButton.button-collapse.top-nav.btn-flat(href='#', data-activates='slide-out', onclick="toggle_visibility('slide-out')", :title="messages.api.action.show_menu")
                         i#target.material-icons menu
                     .nav-wrapper
-                        p.page-title.no-margin(role="heading", aria-level="1") {{messages.api.menu[currentView]}}
+                        h1.page-title.no-margin(role="heading", aria-level="1") {{messages.api.menu[currentView]}}
             ul(role="navigation")#slide-out.side-nav.fixed.may-be-hidden
                 .no-padding.sidenav-header
                     .flex
@@ -57,8 +57,9 @@ block content
                             li
                                 details
                                     summary.collapsible-header
-                                        a
+                                        a(:title="messages.api.action.change_lang")
                                             i.material-icons language
+                                            span {{messages.api.action.language}}
                                     ul.collapsible-body
                                         li.bold
                                             a(href='#', @click="getMessages('fr')", lang="fr") Français
@@ -67,7 +68,6 @@ block content
         main
             .container
                 component(:is='currentView', :methods='methods', :messages='messages', :infos='infos', :current_view.sync='currentView', :currentmethod='currentMethod', :user='user' :get_user='getUser')
-
 
 block script
     script(type='text/javascript', src='/javascripts/app.js')

--- a/views/templates/home.jade
+++ b/views/templates/home.jade
@@ -2,7 +2,7 @@
 script#home-dashboard(type='text/x-template').
     <div>
     <div v-if="messages.api">
-       <h4>{{messages.api.title}}</h4>
+       <h2>{{messages.api.title}}</h2>
        <p>
        <img class= "lock-solid" src="images/logo-transparent.png" style="max-width: 150px; float: right;" alt="">
        {{messages.api.home.description}}
@@ -14,13 +14,13 @@ script#home-dashboard(type='text/x-template').
       <p>
       <img :src="'images/'+method.name+'.svg'" style="max-width: 200px;" alt="">
      </p>
-     
+
       <span>{{messages.api.home[method.name]}}</span>
       <span v-if="user.methods[method.name]?.active" class="status enabled">{{messages.api.home.activated}}</span>
       <span v-else class="status disabled">{{messages.api.home.deactivated}}</span>
      </button>
 
      </div>
-     
+
     </div>
     </div>

--- a/views/templates/push-method.jade
+++ b/views/templates/push-method.jade
@@ -18,7 +18,7 @@ script#push-method(type='text/x-template').
     <div class="card-action">
     <div class="row" style="margin-bottom: 0;">
     <div class="col s1 m2"><span class="white-text"></span></div>
-    <div class="col s10 m8" style="text-align: justify;">
+    <div class="col s10 m8">
     <p>{{messages.api.methods.push.push_confirmation2}}</p>
     <p>{{messages.api.methods.push.push_confirmation3}} {{user.uid}}</p>
     <p>{{messages.api.methods.push.push_confirmation4}} {{user.methods.push.activationCode}}</p>

--- a/views/templates/totp-method.jade
+++ b/views/templates/totp-method.jade
@@ -6,7 +6,7 @@ script#totp-method(type='text/x-template').
     <div class="col s12 m6">
     <div class="card-image" style="padding: 0 1em">
     <div class="row" style="margin-bottom: 0;">
-    <p class="col s12 no-margin" style="text-align: justify;">{{messages.api.methods.totp.howTo}}</p>
+    <p class="col s12 no-margin">{{messages.api.methods.totp.howTo}}</p>
     </div>
     </div>
     <div class="card-content" style="text-align: center;">
@@ -19,7 +19,7 @@ script#totp-method(type='text/x-template').
     <div class="hide-on-med-and-up divider grey lighten-2" style="margin-bottom: 1em;" ></div>
     <div class="card-image" style="padding: 0 1em">
     <div class="row" style="margin-bottom: 0;">
-    <p class="col s12 no-margin" style="text-align: justify;">{{messages.api.methods.totp.howToActivate}}</p>
+    <p class="col s12 no-margin">{{messages.api.methods.totp.howToActivate}}</p>
     </div>
     </div>
     <div class="card-content">

--- a/views/templates/transportForm.pug
+++ b/views/templates/transportForm.pug
@@ -4,7 +4,7 @@ script#transport_form(type='text/x-template').
       <div class="col s2 m3">
         <img :src="`images/${transport}.svg`" alt="">
       </div>
-      <div class="col s10 m9" style="text-align: justify;">
+      <div class="col s10 m9">
         <div class="row" v-if="user.transports[transport]">
           <p class="col s7">{{ user.transports[transport] }}</p>
         </div>

--- a/views/templates/user-dashboard.jade
+++ b/views/templates/user-dashboard.jade
@@ -2,7 +2,7 @@ script#user-dashboard(type='text/x-template').
    <div>
       <div class="section method-section" v-for="method in methods" v-if="method.activate && currentmethod==method.name" autofocus aria-live="assertive">
          <div class="method-header">
-            <h4>{{method.label || method.name}}</h4>
+            <h2 class="h3">{{method.label || method.name}}</h2>
             <p>
                {{messages.api.methods[method.name].description}}
             </p>


### PR DESCRIPTION
* Increase duration of all toasted errors
* Replace some "b" html tags by "strongs"
* Use non breakable spaces in french strings punctuations
* Remove unwanted spaces in English strings (no spaces before punctuations in english)
* Display textual "language" on language icon
* CSS : add styles for heading (h1,2,3...)
* page-title now use H1 instead of p
* Correct some heading hierarchy
* Remove every `text-align: justify` (Avoid Justify align in every web pages for Accessibility)