### PR TITLE
Feature/better logging

### DIFF
--- a/client/sockets.js
+++ b/client/sockets.js
@@ -2,6 +2,7 @@
  * Created by abousk01 on 07/09/2016.
  */
 var properties = require(__dirname+'/../properties/properties');
+const logger = require(__dirname + '/../services/logger');
 
 var apiSockets = require("socket.io-client").connect(properties.esup.api_url, {reconnect: true, path: "/sockets", query: 'app=manager', extraHeaders: {
     Authorization: "Bearer " + properties.esup.api_password,
@@ -10,7 +11,7 @@ var sockets = require('../server/sockets');
 var users = {};
 
 apiSockets.on('connect', function () {
-    console.log("Api Sockets connected");
+    logger.info("Api Sockets connected");
     apiSockets.emit('managers',properties.esup.admins.concat(properties.esup.managers));
 });
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "socket.io-client": "4.x",
     "sweetalert2": "11.x",
     "undici": "6.x",
-    "vue": "2.x"
+    "vue": "2.x",
+    "winston": "3.x"
   },
   "overrides": {
     "express-socket.io-session": {

--- a/properties/esup.json
+++ b/properties/esup.json
@@ -31,6 +31,10 @@
         "access": {
             "format": "combined",
             "file": "/var/log/esup-otp-manager/access.log"
+        },
+        "error": {
+            "level": "info",
+            "file": "/var/log/esup-otp-manager/error.log"
         }
     }
 }

--- a/properties/esup.json
+++ b/properties/esup.json
@@ -26,5 +26,11 @@
     "default_language": "en",
     "dev": {},
     "#how_to":"Usually CAS works in Secure mode, so ssBaseURL must be a HTTPS url",
-    "trustedProxies": ["127.0.0.1", "loopback", "::1"]
+    "trustedProxies": ["127.0.0.1", "loopback", "::1"],
+    "logs": {
+        "access": {
+            "format": "combined",
+            "file": "/var/log/esup-otp-manager/access.log"
+        }
+    }
 }

--- a/server/app.js
+++ b/server/app.js
@@ -38,12 +38,13 @@ app.use('/js/sweetalert2.all.min.js', express.static(path.join(__dirname + '/..'
 
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
+const format = properties.esup.logs.access.format || 'dev';
 if (properties.esup.logs.access.file) {
     var stream = fs.createWriteStream(properties.esup.logs.access.file, { flags: 'a' });
 } else {
     var stream = process.stdout;
 }
-app.use(logger(properties.esup.logs.access.format, { stream: stream }));
+app.use(logger(format, { stream: stream }));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());

--- a/server/app.js
+++ b/server/app.js
@@ -38,13 +38,15 @@ app.use('/js/sweetalert2.all.min.js', express.static(path.join(__dirname + '/..'
 
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
-const format = properties.esup.logs.access.format || 'dev';
-if (properties.esup.logs.access.file) {
-    var stream = fs.createWriteStream(properties.esup.logs.access.file, { flags: 'a' });
-} else {
-    var stream = process.stdout;
+if (properties.esup.logs.access) {
+    const format = properties.esup.logs.access.format || 'dev';
+    if (properties.esup.logs.access.file) {
+        var stream = fs.createWriteStream(properties.esup.logs.access.file, { flags: 'a' });
+    } else {
+        var stream = process.stdout;
+    }
+    app.use(logger(format, { stream: stream }));
 }
-app.use(logger(format, { stream: stream }));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());

--- a/server/app.js
+++ b/server/app.js
@@ -15,6 +15,7 @@ var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 var passport = require('passport');
+var fs = require('fs');
 
 var app = express();
 var sockets = require('./sockets');
@@ -37,7 +38,12 @@ app.use('/js/sweetalert2.all.min.js', express.static(path.join(__dirname + '/..'
 
 // uncomment after placing your favicon in /public
 //app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
-app.use(logger('dev'));
+if (properties.esup.logs.access.file) {
+    var stream = fs.createWriteStream(properties.esup.logs.access.file, { flags: 'a' });
+} else {
+    var stream = process.stdout;
+}
+app.use(logger(properties.esup.logs.access.format, { stream: stream }));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());

--- a/server/routes/apiRoutes.js
+++ b/server/routes/apiRoutes.js
@@ -1,6 +1,7 @@
 const { request } = require('undici');
 const properties = require(__dirname + '/../../properties/properties');
 const utils = require(__dirname + '/../../services/utils');
+const logger = require(__dirname + '/../../services/logger');
 
 function redirect(req, res, status, path) {
     res
@@ -48,7 +49,7 @@ function isAdmin(req, res, next) {
 
 /** @param {{ relUrl: string, queryParams?: Object; bearerAuth?: true, method?: 'GET'|'POST'|'PUT'|'DELETE' }} opts_ */
 async function request_otp_api(req, res, opts_) {
-    console.log("requesting api");
+    logger.info("requesting api");
     const clientIP = req.ip;
     const userAgent = req.headers['user-agent'];
     /**
@@ -77,8 +78,8 @@ async function request_otp_api(req, res, opts_) {
         opts.headers.Authorization = 'Bearer ' + properties.esup.api_password;
     }
 
-    //console.log(opts.method +':'+ opts.url);
-    //console.log(req.session.passport);
+    //logger.info(opts.method +':'+ opts.url);
+    //logger.info(req.session.passport);
     let response;
     try {
         response = await request(url, opts);
@@ -100,7 +101,7 @@ async function request_otp_api(req, res, opts_) {
     res.status(response.statusCode);
     /** @type {Object} */
     const infos = await response.body.json();
-    //console.log(infos)
+    //logger.info(infos)
     res.send(infos);
 }
 

--- a/server/routes/pagesRoutes.js
+++ b/server/routes/pagesRoutes.js
@@ -1,5 +1,6 @@
 const properties = require(__dirname + '/../../properties/properties');
 const utils = require(__dirname + '/../../services/utils');
+const logger = require(__dirname + '/../../services/logger');
 
 function isUser(req, res, next) {
     if (utils.isAuthenticated(req)) return next();
@@ -37,18 +38,18 @@ exports.routing = function(router, passport) {
     router.get('/login', function(req, res, next) {
         passport.authenticate('cas', function(err, user, info) {
             if (err) {
-                console.log(err);
+                logger.error(err);
                 return next(err);
             }
 
             if (!user) {
-                console.log(info.message);
+                logger.info(info.message);
                 return res.redirect('/');
             }
 
             req.logIn(user, function(err) {
                 if (err) {
-                    console.log(err);
+                    logger.error(err);
                     return next(err);
                 }
                 req.session.messages = '';

--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,7 @@ var app = require('../server/app');
 var debug = require('debug')('esup-otp-manager:server');
 var http = require('http');
 var properties = require(__dirname + '/../properties/properties');
+const logger = require('../services/logger');
 
 /**
  * Get port from environment and store in Express.
@@ -15,7 +16,7 @@ var properties = require(__dirname + '/../properties/properties');
 
 var port = normalizePort(properties.esup.port || process.env.PORT || '4000');
 app.set('port', port);
-console.log("Port: " + port);
+logger.info("Port: " + port);
 
 /**
  * Create HTTP server.

--- a/services/logger.js
+++ b/services/logger.js
@@ -1,0 +1,22 @@
+const winston = require('winston');
+const path = require('node:path');
+const properties = require(__dirname + '/../properties/properties');
+
+const logger = winston.createLogger({
+    level: properties.esup.logs.error.level || 'info',
+    format: winston.format.combine(
+        winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+        winston.format.printf(options => {
+            return `${options.timestamp} ${options.level.toUpperCase()} ${undefined !== options.message ? options.message : ''}` +
+                (options.meta && Object.keys(options.meta).length ? `\n\t${JSON.stringify(options.meta)}` : '');
+        })
+    ),
+});
+
+if (properties.esup.logs.error.file) {
+   logger.add(new winston.transports.File({ filename: properties.esup.logs.error.file }));
+} else {
+    logger.add(new winston.transports.Console());
+}
+
+module.exports = logger;


### PR DESCRIPTION
Those changes allow to configure logging, instead of cloggering stdout with endless noise, such as load-balancer monitor requests for instance.

The choice of "access" vs "error" log comes from Apache terminology (access logs vs error logs), but "generic" vs "access", or any other similar terminology may be OK too.