### PR TITLE
Proposition message titre/index plus générique

### DIFF
--- a/properties/messages_en.json
+++ b/properties/messages_en.json
@@ -116,7 +116,7 @@
       "deactivated": "Deactivated",
       "note":"Set up at least 2 methods among:"
     },
-    "index": "Single use passwords management interface",
+    "index": "Multi-Factor Authentication Management Interface",
     "action":{
       "connection": "Login",
       "activate": "Activate",

--- a/properties/messages_fr.json
+++ b/properties/messages_fr.json
@@ -117,7 +117,7 @@
       "deactivated": "Désactivé",
       "note": "Dans vos préférences, nous vous conseillons fortement de paramétrer au moins 2 méthodes afin de pouvoir assurer la continuité d’utilisation des services numériques."
     },
-    "index": "Interface de gestion de mots de passe à usage unique",
+      "index": "Interface de gestion de l'authentification renforcée (multi-facteurs)",
     "action":{
       "connection": "Se connecter",
       "activate": "Activer",

--- a/properties/messages_fr.json
+++ b/properties/messages_fr.json
@@ -117,7 +117,7 @@
       "deactivated": "Désactivé",
       "note": "Dans vos préférences, nous vous conseillons fortement de paramétrer au moins 2 méthodes afin de pouvoir assurer la continuité d’utilisation des services numériques."
     },
-      "index": "Interface de gestion de l'authentification renforcée (multi-facteurs)",
+      "index": "Interface de gestion de l’authentification renforcée (multi-facteurs)",
     "action":{
       "connection": "Se connecter",
       "activate": "Activer",

--- a/properties/messages_fr.json
+++ b/properties/messages_fr.json
@@ -117,7 +117,7 @@
       "deactivated": "Désactivé",
       "note": "Dans vos préférences, nous vous conseillons fortement de paramétrer au moins 2 méthodes afin de pouvoir assurer la continuité d’utilisation des services numériques."
     },
-      "index": "Interface de gestion de l’authentification renforcée (multi-facteurs)",
+      "index": "Interface de gestion de l’authentification renforcée (multifacteur)",
     "action":{
       "connection": "Se connecter",
       "activate": "Activer",


### PR DESCRIPTION
"Single use passwords management interface" ("Interface de gestion de mots de passe à usage unique") est trop restrictif : ça réduit la portée à des OTPs à usage unique, alors que l’outil gère une authentification multi-facteurs au sens large.