### PR TITLE
Add contextual help texts to enable or disable methods

### DIFF
--- a/properties/messages_en.json
+++ b/properties/messages_en.json
@@ -21,6 +21,8 @@
       "totp": {
         "name": "Timed password (TOTP)",
         "description": "This method generate 6 numerals codes",
+        "help_is_active": "This method is on.<br>🔁 To <strong>revoke</strong> the current secret and <strong>create a new set</strong> of one-time codes, click on « Generate QRcode » button.<br>⏹️ To <strong>revoke</strong> the current secret and <strong>disable the method</strong>, click on the switch.",
+        "help_is_inactive": "This method is off.<br>▶️ <strong>To enable it</strong>, please follow the 2 steps bellow.",  
         "apple_passwords_app": "Apple Passwords app",
         "registration_instructions": {
           "deeplink": "<strong><a href='%DEEPLINK%'>Click here</a></strong> to register your key in the %ESUP_AUTH% app (after installing the app).",
@@ -35,6 +37,8 @@
       "random_code": {
         "name": "One time password",
         "description": "Method to generate random codes valid for some time",
+        "help_is_active": "",
+        "help_is_inactive": "",
         "verify_code": {
           "sms": {
             "title": "Code received by SMS",
@@ -63,11 +67,15 @@
       },
       "random_code_mail": {
         "name": "One time password by mail",
-        "description": "Method to generate random codes and sent it by mail"
+        "description": "Method to generate random codes and sent it by mail",
+        "help_is_active": "This method is on.<br>🔁 To <strong>send your codes to another email adress (which will replace current one)</strong>, registrer the new adress bellow and follow the instructions. You will have to enter or copy a code sent to this new adress to complete the change.<br>⏹️ To <strong>delete the current email adress</strong> and <strong>disable the method</strong>, click on « Remove ».",
+        "help_is_inactive": "This method is off.<br>▶️ <strong>To enable it</strong>, registrer your email adress bellow and follow the instructions. You will have to enter or copy a code sent to this adress to validate the activation.<br>NB. If no text field is visible, click on the switch before to enable the method."
       },
       "bypass": {
         "name": "Backup codes",
         "description": "Method for generating a random codes list",
+        "help_is_active": "",
+        "help_is_inactive": "",
         "generated_codes": "Generated codes",
         "available_codes": "Available codes",
         "used_codes": "Used codes",
@@ -77,12 +85,16 @@
       "passcode_grid": {
         "name": "Passcode grid",
         "description": "Method for generating a grid of random codes",
+        "help_is_active": "This method is on.<br>🔁 To <strong>revoke</strong> current codes and <strong>get new ones</strong>, click on « Generate codes » on page bottom.<br><strong>Be careful</strong> : theses codes won't show up again, save it in your password vault before leaving the page.<br>⏹️ To <strong>revoke</strong> current codes and <strong>disable the method</strong>, click on « Generate codes » on page bottom then on the switch to deactivate.",
+        "help_is_inactive": "This method is off.<br>▶️ <strong>To enable it</strong>, click on the switch then on « Generate codes » button.<br><strong>Be careful</strong> : theses codes won't show up again, save it in your password vault before leaving the page.",
         "note": "Do not photograph. Do not share.<br>In case of loss, contact the DSIUN.",
         "generation_date": "Codes generated on %DATE%"
       },
       "push": {
         "name": "Notification (Esup Auth)",
         "description": "Method for connecting via smartphone notifications with Esup Auth",
+        "help_is_active": "This method is on and can send notifications to the associated device listed bellow.<br>⏹️ To <strong>revoke</strong> the pairing and the current secret, click on the switch to deactivate the method. After this, you would be able to enable the method again and to pair a new device.",
+        "help_is_inactive": "This method is off.<br>▶️ <strong>To enable it</strong>, follow the steps bellow.<br>NB. If no step is displayed, click on the switch before to enable the method.",
         "esup_auth_download_link": "Esup Auth on <a href='%ANDROID_URL%' target='_blank'>Android</a> or <a href='%IOS_URL%' target='_blank'>IOS</a>",
         "esup_Auth_installation_instructions": "After installing the %ESUP_AUTH% app",
         "deeplink_instructions": "<strong><a href='%DEEP_LINK%'>Click here</a></strong>,",
@@ -100,11 +112,15 @@
       },
       "esupnfc": {
         "name": "EsupNFC",
-        "description": "Method for connecting via NFC swipe"
+        "description": "Method for connecting via NFC swipe",
+        "help_is_active": "",
+        "help_is_inactive": ""
       },
       "webauthn": {
         "name": "Hardware authenticator (WebAuthn)",
         "description": "WebAuthn hardware authentication factor (Smartphone, Windows Hello, TouchID, ...).",
+        "help_is_active": "This method is on. Devices authorized for your authentication are listed bellow.<br>You can <strong>edit or remove each authorization</strong>.",
+        "help_is_inactive": "This method is off.<br>▶️ <strong>To enable it</strong>, please get the device you want to pair ready (phone, security key, ...), click on « Add » and follow the instructions provided by your browser and device.",
         "no_authentificators": "You have no authentificators registered. Register one?",
         "single_auth": "You have 1 authentification method registered.",
         "nb_of_auths": "You have %NB% authentification methods registered.",

--- a/properties/messages_fr.json
+++ b/properties/messages_fr.json
@@ -21,7 +21,7 @@
       "totp": {
         "name": "Code temporel (TOTP)",
         "description": "Méthode permettant de générer des codes uniques de 6 chiffres.",
-        "help_is_active": "Cette méthode est active.<br>🔁 Pour <strong>révoquer</strong> le secret actuel et <strong>générer une nouvelle série</strong> de codes uniques, cliquez sur le bouton « Générer QRcode ».<br>⏹️ Pour <strong>révoquer</strong> le secret actuel et <strong>désactiver la méthode</strong>, cliquez sur la réglette pour désactiver.",
+        "help_is_active": "Cette méthode est active.<br>🔁 Pour <strong>révoquer</strong> le secret actuel et <strong>générer une nouvelle série</strong> de codes uniques, cliquez sur le bouton « Générer QRcode ».<br>⏹️ Pour <strong>révoquer</strong> le secret actuel et <strong>désactiver la méthode</strong>, cliquez sur la réglette.",
         "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, suivez les 2 étapes décrites ci-après.",
         "apple_passwords_app": "l’application Apple « Mots de passe »",
         "registration_instructions": {
@@ -69,7 +69,7 @@
         "name": "Code par Courriel",
         "description": "Méthode permettant de s’authentifier à partir d’un code aléatoire à usage unique envoyé par courriel."
         "help_is_active": "Cette méthode est active.<br>🔁 Pour <strong>recevoir vos codes sur une autre adresse (remplaçant l'actuelle)</strong>, enregistrez la nouvelle adresse ci-après puis suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette nouvelle adresse pour confirmer le remplacement.<br>⏹️ Pour <strong>supprimer l'adresse</strong> actuelle et <strong>désactiver la méthode</strong>, cliquer sur « Supprimer ».",
-        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, cliquez sur la réglette puis enregistrez votre adresse courriel ci-après et suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette adresse pour confirmer l'activation de la méthode.",
+        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, enregistrez votre adresse courriel ci-après et suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette adresse pour confirmer l'activation de la méthode.",
       },
       "bypass": {
         "name": "Codes de secours",
@@ -93,8 +93,8 @@
       "push": {
         "name": "Notification (Esup Auth)",
         "description": "Méthode permettant de se connecter via les notifications de son smartphone avec l’application Esup Auth.",
-        "help_is_active": "",
-        "help_is_inactive": "",
+        "help_is_active": "Cette méthode est active et notifie l'appareil associé ci-après.<br>⏹️ Pour <strong>révoquer</strong> l'association et le secret actuels, cliquez sur la réglette pour désactiver. Vous aurez ensuite la possibilité d'associer un nouvel appareil en réactivant la méthode.",
+        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, suivez les étapes décrites ci-après. Si besoin, cliquez au préalable sur la réglette.",
         "esup_auth_download_link": "Esup Auth sur <a href='%ANDROID_URL%' target='_blank'>Android</a> ou <a href='%IOS_URL%' target='_blank'>IOS</a>",
         "esup_Auth_installation_instructions": "Une fois l'application %ESUP_AUTH% installée,",
         "deeplink_instructions": "<a href='%DEEPLINK%'>Cliquez ici</a>.",

--- a/properties/messages_fr.json
+++ b/properties/messages_fr.json
@@ -67,9 +67,9 @@
       },
       "random_code_mail": {
         "name": "Code par Courriel",
-        "description": "Méthode permettant de s’authentifier à partir d’un code aléatoire à usage unique envoyé par courriel."
+        "description": "Méthode permettant de s’authentifier à partir d’un code aléatoire à usage unique envoyé par courriel.",
         "help_is_active": "Cette méthode est active.<br>🔁 Pour <strong>recevoir vos codes sur une autre adresse (remplaçant l'actuelle)</strong>, enregistrez la nouvelle adresse ci-après puis suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette nouvelle adresse pour confirmer le remplacement.<br>⏹️ Pour <strong>supprimer l'adresse</strong> actuelle et <strong>désactiver la méthode</strong>, cliquer sur « Supprimer ».",
-        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, enregistrez votre adresse courriel ci-après et suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette adresse pour confirmer l'activation.<br>NB. Si le champ de saisie n'apparaît pas, cliquez au préalable sur la réglette pour activer la méthode.",
+        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, enregistrez votre adresse courriel ci-après et suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette adresse pour confirmer l'activation.<br>NB. Si le champ de saisie n'apparaît pas, cliquez au préalable sur la réglette pour activer la méthode."
       },
       "bypass": {
         "name": "Codes de secours",

--- a/properties/messages_fr.json
+++ b/properties/messages_fr.json
@@ -112,9 +112,9 @@
       },
       "esupnfc": {
         "name": "EsupNFC",
-        "description": "Méthode permettant de récupérer un code en badgeant la carte"
+        "description": "Méthode permettant de récupérer un code en badgeant la carte",
         "help_is_active": "",
-        "help_is_inactive": "",
+        "help_is_inactive": ""
       },
       "webauthn": {
         "name": "Facteur physique (WebAuthn)",

--- a/properties/messages_fr.json
+++ b/properties/messages_fr.json
@@ -21,6 +21,8 @@
       "totp": {
         "name": "Code temporel (TOTP)",
         "description": "Méthode permettant de générer des codes uniques de 6 chiffres.",
+        "help_is_active": "Cette méthode est active.<br>🔁 Pour <strong>révoquer</strong> le secret actuel et <strong>générer une nouvelle série</strong> de codes uniques, cliquez sur le bouton « Générer QRcode ».<br>⏹️ Pour <strong>révoquer</strong> le secret actuel et <strong>désactiver la méthode</strong>, cliquez sur la réglette pour désactiver.",
+        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, suivez les 2 étapes décrites ci-après.",
         "apple_passwords_app": "l’application Apple « Mots de passe »",
         "registration_instructions": {
           "deeplink": "<strong><a href='%DEEPLINK%'>Cliquez ici</a></strong> pour enregistrer votre clé dans l'application %ESUP_AUTH% (après avoir installé l'application).",
@@ -35,6 +37,8 @@
       "random_code": {
         "name": "Code par SMS",
         "description": "Méthode permettant de s’authentifier à partir d’un code aléatoire à usage unique envoyé par SMS.",
+        "help_is_active": "",
+        "help_is_inactive": "",
         "verify_code": {
           "sms": {
             "title": "Code reçu par SMS",
@@ -64,10 +68,14 @@
       "random_code_mail": {
         "name": "Code par Courriel",
         "description": "Méthode permettant de s’authentifier à partir d’un code aléatoire à usage unique envoyé par courriel."
+        "help_is_active": "Cette méthode est active.<br>🔁 Pour <strong>recevoir vos codes sur une autre adresse (remplaçant l'actuelle)</strong>, enregistrez la nouvelle adresse ci-après puis suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette nouvelle adresse pour confirmer le remplacement.<br>⏹️ Pour <strong>supprimer l'adresse</strong> actuelle et <strong>désactiver la méthode</strong>, cliquer sur « Supprimer ».",
+        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, cliquez sur la réglette puis enregistrez votre adresse courriel ci-après et suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette adresse pour confirmer l'activation de la méthode.",
       },
       "bypass": {
         "name": "Codes de secours",
         "description": "Méthode permettant de générer une liste de codes aléatoires à usage unique.",
+        "help_is_active": "",
+        "help_is_inactive": "",
         "generated_codes": "Codes générés",
         "available_codes": "Codes restants",
         "used_codes": "Codes utilisés",
@@ -77,12 +85,16 @@
       "passcode_grid": {
         "name": "Grille de codes",
         "description": "Méthode permettant de générer une grille de codes aléatoires.",
+        "help_is_active": "Cette méthode est active.<br>🔁 Pour <strong>révoquer</strong> les codes actuels et en <strong>obtenir de nouveaux</strong>, cliquez sur « Générer des codes » en bas de page.<br><strong>Attention</strong> : ces codes ne seront pas réaffichés, enregistrez-les dans votre coffre-fort avant de quitter la page.<br>⏹️ Pour <strong>révoquer</strong> les codes actuels et <strong>désactiver la méthode</strong>, cliquer sur « Générer des codes » en bas de page puis sur la réglette pour désactiver.",
+        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, cliquez sur la réglette puis sur le bouton « Générer des codes ».<br><strong>Attention</strong> : ces codes ne seront pas réaffichés, enregistrez-les dans votre coffre-fort avant de quitter la page.",
         "note": "Ne pas photographier. Ne pas montrer cette grille à qui que ce soit.<br>En cas de perte ou divulgation, contacter la DSIUN.",
         "generation_date": "Codes générés le %DATE%"
       },
       "push": {
         "name": "Notification (Esup Auth)",
         "description": "Méthode permettant de se connecter via les notifications de son smartphone avec l’application Esup Auth.",
+        "help_is_active": "",
+        "help_is_inactive": "",
         "esup_auth_download_link": "Esup Auth sur <a href='%ANDROID_URL%' target='_blank'>Android</a> ou <a href='%IOS_URL%' target='_blank'>IOS</a>",
         "esup_Auth_installation_instructions": "Une fois l'application %ESUP_AUTH% installée,",
         "deeplink_instructions": "<a href='%DEEPLINK%'>Cliquez ici</a>.",
@@ -101,10 +113,14 @@
       "esupnfc": {
         "name": "EsupNFC",
         "description": "Méthode permettant de récupérer un code en badgeant la carte"
+        "help_is_active": "",
+        "help_is_inactive": "",
       },
       "webauthn": {
         "name": "Facteur physique (WebAuthn)",
         "description": "Facteur physique d’authentification WebAuthn (Smartphone, Windows Hello, TouchID, ...).",
+        "help_is_active": "Cette méthode est active. Les appareils listés ci-après sont vos moyens d'authentification autorisés.<br>Vous pouvez <strong>modifier ou supprimer chaque autorisation</strong> ci-après.",
+        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, préparez l'appareil à associer (téléphone, clé, ...), cliquez sur « Ajouter » puis suivez les indications de votre navigateur et appareil.",
         "no_authentificators": "Vous n’avez pas de moyen d’authentification enregistré. En ajouter un ?",
         "single_auth": "Vous avez 1 moyen d’authentification.",
         "nb_of_auths": "Vous avez %NB% moyens d’authentification.",

--- a/properties/messages_fr.json
+++ b/properties/messages_fr.json
@@ -69,7 +69,7 @@
         "name": "Code par Courriel",
         "description": "Méthode permettant de s’authentifier à partir d’un code aléatoire à usage unique envoyé par courriel."
         "help_is_active": "Cette méthode est active.<br>🔁 Pour <strong>recevoir vos codes sur une autre adresse (remplaçant l'actuelle)</strong>, enregistrez la nouvelle adresse ci-après puis suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette nouvelle adresse pour confirmer le remplacement.<br>⏹️ Pour <strong>supprimer l'adresse</strong> actuelle et <strong>désactiver la méthode</strong>, cliquer sur « Supprimer ».",
-        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, enregistrez votre adresse courriel ci-après et suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette adresse pour confirmer l'activation de la méthode.",
+        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, enregistrez votre adresse courriel ci-après et suivez les indications. Vous aurez à saisir ou copier un code reçu sur cette adresse pour confirmer l'activation.<br>NB. Si le champ de saisie n'apparaît pas, cliquez au préalable sur la réglette pour activer la méthode.",
       },
       "bypass": {
         "name": "Codes de secours",
@@ -94,7 +94,7 @@
         "name": "Notification (Esup Auth)",
         "description": "Méthode permettant de se connecter via les notifications de son smartphone avec l’application Esup Auth.",
         "help_is_active": "Cette méthode est active et notifie l'appareil associé ci-après.<br>⏹️ Pour <strong>révoquer</strong> l'association et le secret actuels, cliquez sur la réglette pour désactiver. Vous aurez ensuite la possibilité d'associer un nouvel appareil en réactivant la méthode.",
-        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, suivez les étapes décrites ci-après. Si besoin, cliquez au préalable sur la réglette.",
+        "help_is_inactive": "Cette méthode n'est pas encore activée.<br>▶️ <strong>Pour l'activer</strong>, suivez les étapes décrites ci-après.<br>NB. Si les étapes ne s'affichent pas, cliquez au préalable sur la réglette.",
         "esup_auth_download_link": "Esup Auth sur <a href='%ANDROID_URL%' target='_blank'>Android</a> ou <a href='%IOS_URL%' target='_blank'>IOS</a>",
         "esup_Auth_installation_instructions": "Une fois l'application %ESUP_AUTH% installée,",
         "deeplink_instructions": "<a href='%DEEPLINK%'>Cliquez ici</a>.",

--- a/views/templates/user-dashboard.pug
+++ b/views/templates/user-dashboard.pug
@@ -17,6 +17,12 @@ script#user-dashboard(type='text/x-template').
           </label>
           <p v-if="user.methods[method.name].askActivation" class="grey-text text-darken-1" style="margin-top: 0">{{ messages.api.home.activating }}</p>
         </div>
+         <div v-if="user.methods[method.name].active && user.methods[method.name].askActivation==false">
+            <p>{{messages.api.methods[method.name].help_is_active}}</p>
+         </div>
+         <div v-else>
+            <p>{{messages.api.methods[method.name].help_is_inactive}}</p>
+         </div>       
          <div class="divider"></div>
          <div class="method-component-wrapper" v-if="user.methods[method.name].active">
             <component :is=currentmethod :method=currentmethod :methods=methods :generate_totp=generateTotpConfirm :generate_bypass=generateBypassConfirm :generate_passcode_grid=generatePasscodeGridConfirm :hasValidTransportForRandom_codeMethod=hasValidTransportForRandom_codeMethod :fetchWebauthnData=fetchWebauthnData :get-and-set-user=getAndSetUser :messages=messages :infos=infos :user=user :formatApiUri=formatApiUri :isManager=false></component>


### PR DESCRIPTION
- Strings are provided in French and English for all methods but are not filled for one-time, SMS nor NFC methods (left empty). It's contextual help to complete the text some methods adds in the frame.
- Two texts for each method : one when the method is off or processing the activation (switch in between), the other if the method is fully on.
- It displays under the activation switch, as it refers to it and let it more quickly visible. 